### PR TITLE
Add newest CKAN history file to the archive

### DIFF
--- a/KSPBugReport/KSPBugReport.cs
+++ b/KSPBugReport/KSPBugReport.cs
@@ -316,6 +316,34 @@ namespace KSPBugReport
                 {
                     Lib.Log($"Could not zip savegame\n{e}", Lib.LogLevel.Warning);
                 }
+                
+                try
+                {
+                    var ckanHistoryDir = new DirectoryInfo(Path.Combine(rootPath, "CKAN", "history"));
+                    if (ckanHistoryDir.Exists)
+                    {
+                        FileInfo newestCkan = null;
+                        foreach (FileInfo fi in ckanHistoryDir.EnumerateFiles("*.ckan"))
+                        {
+                            if (newestCkan == null || newestCkan.LastWriteTimeUtc < fi.LastWriteTimeUtc)
+                            {
+                                newestCkan = fi;
+                            }
+                        }
+                        if (newestCkan != null)
+                        {
+                            using (Stream fileStream = newestCkan.OpenRead())
+                            using (Stream entryStream = archive.CreateEntry(newestCkan.Name, System.IO.Compression.CompressionLevel.Optimal).Open())
+                            {
+                                fileStream.CopyTo(entryStream);
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Lib.Log($"Could not zip CKAN history file\n{e}", Lib.LogLevel.Warning);
+                }
             }
             return true;
         }


### PR DESCRIPTION
## Motivation

It would be nice to capture some basic CKAN info for bug reports, see KSP-CKAN/CKAN#1012 and to some extent KSP-CKAN/CKAN#1031.

Discussed somewhat in KSP-CKAN/NetKAN#8430.

## Background

Whenever CKAN installs or uninstalls any mods, it creates a modpack file at `<KSP>/CKAN/history/installed-<instance name>-<date and time>.ckan`, looking something like this:

```json
{
    "spec_version": "v1.18",
    "identifier": "installed-Steam",
    "name": "installed-Steam",
    "abstract": "A list of modules installed on the Steam KSP instance",
    "version": "2020.12.06.01.18.06",
    "license": [
        "unknown"
    ],
    "depends": [
        {
            "name": "MakingHistory-DLC",
            "version": "1.10.1"
        },
        {
            "name": "BreakingGround-DLC",
            "version": "1.5.1"
        },
        {
            "name": "4kSPExpanded",
            "version": "0.2.0"
        },
        {
            "name": "ActionGroupManager",
            "version": "1:2.2.6"
        },
        {
            "name": "AdvancedFlyByWire",
            "version": "1.8.3.2"
        },
        {
            "name": "AltimeterAutoHide",
            "version": "1.1"
        },
        {
            "name": "ToolbarController",
            "version": "1:0.1.9.4"
        },
        {
            "name": "ClickThroughBlocker",
            "version": "1:0.1.10.14"
        },
        {
            "name": "ZeroMiniAVC",
            "version": "1:1.1.0.1"
        },
        {
            "name": "KopernicusTech",
            "version": "0.13"
        },
        {
            "name": "OuterPlanetsMod",
            "version": "1.6.5"
        },
        {
            "name": "ModuleManager",
            "version": "4.1.4"
        },
        {
            "name": "RSSTextures16K",
            "version": "v18.3"
        }
    ],
    "kind": "metapackage"
}
```

Having this file would allow anyone inspecting the bug report to see what mods the user had installed via CKAN, if any.

## Changes

Now if the CKAN history folder exists, we find the newest .ckan file in it and copy it to the ZIP.

FYI to @gotmachine and @DasSkelett.